### PR TITLE
Fix: 500 error on login failure

### DIFF
--- a/auth-server/src/main/java/com/example/authserver/config/SecurityConfig.java
+++ b/auth-server/src/main/java/com/example/authserver/config/SecurityConfig.java
@@ -39,6 +39,12 @@ import java.util.UUID;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final LoggingAuthenticationFailureHandler loggingAuthenticationFailureHandler;
+
+    public SecurityConfig(LoggingAuthenticationFailureHandler loggingAuthenticationFailureHandler) {
+        this.loggingAuthenticationFailureHandler = loggingAuthenticationFailureHandler;
+    }
+
     @Bean
     @Order(1)
     public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -61,7 +67,8 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/.well-known/**").permitAll()
                 .anyRequest().authenticated()
             )
-            .formLogin(Customizer.withDefaults());
+                .formLogin(form -> form
+                        .failureHandler(loggingAuthenticationFailureHandler));
         return http.build();
     }
 

--- a/auth-server/src/main/java/com/example/authserver/handler/LoggingAuthenticationFailureHandler.java
+++ b/auth-server/src/main/java/com/example/authserver/handler/LoggingAuthenticationFailureHandler.java
@@ -11,6 +11,9 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationFa
 
 import java.io.IOException;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class LoggingAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingAuthenticationFailureHandler.class);


### PR DESCRIPTION
The application was returning a 500 internal server error upon a failed login attempt. This was caused by the absence of an explicitly configured `AuthenticationFailureHandler` in the Spring Security configuration.

This commit addresses the issue by:
1.  Annotating `LoggingAuthenticationFailureHandler` with `@Component` to make it a Spring bean.
2.  Injecting `LoggingAuthenticationFailureHandler` into `SecurityConfig`.
3.  Explicitly setting the custom handler in the `formLogin` configuration.

This ensures that login failures are gracefully handled by redirecting the user to `/login?error`, preventing the 500 error.